### PR TITLE
Fix CVE-2015-7541

### DIFF
--- a/lib/colorscore/histogram.rb
+++ b/lib/colorscore/histogram.rb
@@ -1,7 +1,7 @@
 module Colorscore
   class Histogram
     def initialize(image_path, colors=16, depth=8)
-      output = `convert #{image_path} -resize 400x400 -format %c -dither None -quantize YIQ -colors #{colors} -depth #{depth} histogram:info:-`
+      output = `convert #{image_path.inspect} -resize 400x400 -format %c -dither None -quantize YIQ -colors #{colors.to_i} -depth #{depth.to_i} histogram:info:-`
       @lines = output.lines.sort.reverse.map(&:strip).reject(&:empty?)
     end
 


### PR DESCRIPTION
Avoid passsing possible user input directly into the shell. Instead
quote the `image_path` value before calling the `convert` command.

See here http://rubysec.com/advisories/CVE-2015-7541/ for more
information.
