### PR TITLE
fixed doesn't parse RGB from srgba

### DIFF
--- a/lib/colorscore/histogram.rb
+++ b/lib/colorscore/histogram.rb
@@ -9,7 +9,7 @@ module Colorscore
 
     # Returns an array of colors in descending order of occurances.
     def colors
-      hex_values = @lines.map { |line| line[/#([0-9A-F]{6}) /, 1] }.compact
+      hex_values = @lines.map { |line| line[/#([0-9A-F]{6})/, 1] }.compact
       hex_values.map { |hex| Color::RGB.from_html(hex) }
     end
 


### PR DESCRIPTION
i've figured out why doesn't parse png files.
cuz wrong REGEX.

```
$ convert '가나다라마법사.jpg' -resize 400x400 -format %c -dither None -quantize YIQ -colors 1 -depth 8 histogram:info:-
    135200: (141,146,140) #8D928C srgb(141,146,140)

===> it's ok. RGB decimals length is 6

but, png file

$ convert '간장공장공장장.png' -resize 400x400 -format %c -dither None -quantize YIQ -colors 1 -depth 8 histogram:info:-
    119600: (117,118,121,255) #757679FF srgba(117,118,121,1)

===> um.. RGB decimals length has 8 include alpha value.
```

i had fix wrong REGEX. please check it out. thank you :)